### PR TITLE
fix/otp verification page even when login fails

### DIFF
--- a/components/sections/auth/login.tsx
+++ b/components/sections/auth/login.tsx
@@ -41,10 +41,7 @@ export default function AuthLogin() {
 
     startTransition(async () => {
       try {
-        loginMutation.mutate(email);
-        if (error) {
-          throw error;
-        }
+        await loginMutation.mutateAsync(email);
         router.push("/auth/verify-otp?email=" + encodeURIComponent(email));
       } catch (error: unknown) {
         setError(error instanceof Error ? error.message : "An error occurred");


### PR DESCRIPTION
-previously --> user was navigated to otp verification page even when user request  otp with wrong email 
-now -->throws error and user is prevented to navigate to otp verification page